### PR TITLE
Extend deadline

### DIFF
--- a/jowo2022/index.md
+++ b/jowo2022/index.md
@@ -53,6 +53,5 @@ Reviews will consider the novelty, significance and soundness of the respective 
 ## Timeline
 
 * Submission deadline - ~~June 3rd~~ **June 17th, 2022**
-* Review Assignment - June 20th, 2022
 * Review deadline - July 8th, 2022
 * Camera ready version due - August 5th, 2022

--- a/jowo2022/index.md
+++ b/jowo2022/index.md
@@ -52,6 +52,7 @@ Reviews will consider the novelty, significance and soundness of the respective 
 
 ## Timeline
 
-* Submission deadline - June 3rd, 2022
-* Notification date - July 15th, 2022
+* Submission deadline - ~~June 3rd~~ **June 17th, 2022**
+* Review Assignment - June 20th, 2022
+* Review deadline - July 8th, 2022
 * Camera ready version due - August 5th, 2022


### PR DESCRIPTION
We decided to extend the submission deadline by two weeks (June 17th). This should give reviewers 3 weeks of time to write their reviews and, after notification, an additional 3 weeks to amend the camera-ready versions of accepted submissions.